### PR TITLE
update script output to use correct url

### DIFF
--- a/deconz-phoscon-hoobs.sh
+++ b/deconz-phoscon-hoobs.sh
@@ -146,4 +146,4 @@ echo "----------------------------------------------------------------"
 echo "Starting deCONZ Service"
 systemctl restart deconz
 echo "----------------------------------------------------------------"
-echo "Phoscon Interface is now reachable at homebridge.local:1881"
+echo "Phoscon Interface is now reachable at hoobs.local:1881"


### PR DESCRIPTION
Currently the script output states that the Phoscon interface will be available at `homebridge.local:1881`, when in reality it will be at `hoobs.local:1881`. This change updates the language to use the correct URL.